### PR TITLE
fix compound dtypes issue

### DIFF
--- a/floater/utils.py
+++ b/floater/utils.py
@@ -237,6 +237,10 @@ def floats_to_netcdf(input_dir, output_fname,
         Reference time, format: YYYY-MM-DD
     step_time: int
         Step time, unit: second
+    output_dir: path
+        Where to store the transcoded NetCDF files
+    output_prefix: str
+        Prefix of the transcoded NetCDF files
     """
     import dask.dataframe as dd
     import xarray as xr
@@ -252,13 +256,9 @@ def floats_to_netcdf(input_dir, output_fname,
     float_columns = ['npart', 'time', 'x', 'y', 'z', 'u', 'v', 'vort']
     var_names = float_columns[2:]
 
-    var_int = [('npart', np.int32)]
-    var_float = [(var, np.float32) for var in float_columns[1:]]
-    float_dtypes = np.dtype(var_int+var_float)
-
     for float_timestep in float_timesteps:
         input_path = input_dir + float_timestep + '.*.csv'
-        df = dd.read_csv(input_path, names=float_columns, dtype=float_dtypes, header=None)
+        df = dd.read_csv(input_path, names=float_columns, header=None)
         dfc = df.compute()
         dfcs = dfc.sort_values('npart')
         step_time = int(step_time)
@@ -269,9 +269,9 @@ def floats_to_netcdf(input_dir, output_fname,
             time = np.array([ref_time+del_time])
         else:
             time = np.array([np.int32(step_num)])
-        npart = dfcs.npart.values
+        npart = np.int32(dfcs.npart.values)
         var_shape = (1, len(npart))
-        data_vars = {var_name: (['time', 'npart'], dfcs[var_name].values.reshape(var_shape)) for var_name in var_names}
+        data_vars = {var_name: (['time', 'npart'], np.float32(dfcs[var_name].values).reshape(var_shape)) for var_name in var_names}
         ds = xr.Dataset(data_vars, coords={'time': time, 'npart': npart})
         output_path = output_dir + output_fname + '/'
         if not os.path.exists(output_path):

--- a/floater/utils.py
+++ b/floater/utils.py
@@ -269,9 +269,9 @@ def floats_to_netcdf(input_dir, output_fname,
             time = np.array([ref_time+del_time])
         else:
             time = np.array([np.int32(step_num)])
-        npart = np.int32(dfcs.npart.values)
+        npart = dfcs.npart.values.astype(np.int32)
         var_shape = (1, len(npart))
-        data_vars = {var_name: (['time', 'npart'], np.float32(dfcs[var_name].values).reshape(var_shape)) for var_name in var_names}
+        data_vars = {var_name: (['time', 'npart'], dfcs[var_name].values.astype(np.float32).reshape(var_shape)) for var_name in var_names}
         ds = xr.Dataset(data_vars, coords={'time': time, 'npart': npart})
         output_path = output_dir + output_fname + '/'
         if not os.path.exists(output_path):


### PR DESCRIPTION
cc: @rabernat, @nathanieltarshish

This pull request fixes #38 by removing the dtype option in `df = dd.read_csv(input_path, names=float_columns, dtype=float_dtypes, header=None)` and setting variable dtypes later.