### PR TITLE
Projection

### DIFF
--- a/floater/rclv.py
+++ b/floater/rclv.py
@@ -262,7 +262,7 @@ def convex_contour_around_maximum(data, ji, step, border=5,
         else:
             contour_proj = project_vertices(contour, **proj_kwargs)
 
-        region_area, hull_area, cd = contour_area(contour)
+        region_area, hull_area, cd = contour_area(contour_proj)
         if verbose:
             print('  region_area: % 6.1f, hull_area: % 6.1f, convex_def: % 6.5e'
                   % (region_area, hull_area, cd))

--- a/floater/test/test_rclv.py
+++ b/floater/test/test_rclv.py
@@ -168,14 +168,18 @@ def test_convex_contour_around_maximum_projected(sample_data_and_maximum,
     proj_kwargs = dict(
         dlon=lon[1] - lon[0],
         dlat=lat[1] - lat[0],
-        lon0=lon.mean(),
-        lat0=lat.mean(),
+        lon0=lon[ji[1]],
+        lat0=lat[ji[0]],
     )
 
     # step determines how precise the contour identification is
     step = 0.001
     con, area = rclv.convex_contour_around_maximum(psi, ji, step,
                                 proj_kwargs=proj_kwargs)
+
+    # check against reference solution
+    np.testing.assert_allclose(area, 2375686527)
+    assert len(con) == 261
 
 
 
@@ -195,3 +199,21 @@ def test_find_convex_contours(sample_data_and_maximum):
     assert labels.max() == 1
     assert labels.min() == 0
     assert labels.sum() == 2693
+
+
+def test_find_convex_contours_projected(sample_data_and_maximum,
+                                        sample_data_lon_lat):
+    psi, ji, psi_max = sample_data_and_maximum
+    lon, lat = sample_data_lon_lat
+
+    with pytest.raises(ValueError):
+        _ = list(rclv.find_convex_contours(psi, step=0.001, lon=lon[1:], lat=lat))
+
+    res = list(rclv.find_convex_contours(psi, step=0.001, lon=lon, lat=lat))
+
+    assert len(res) == 1
+
+    ji_found, con, area = res[0]
+    assert tuple(ji_found) == ji
+    assert len(con) == 261
+    np.testing.assert_allclose(area, 2375686527)

--- a/floater/test/test_rclv.py
+++ b/floater/test/test_rclv.py
@@ -17,9 +17,27 @@ def sample_data_and_maximum():
     ji = (50,45)
     return psi, ji, psi[ji]
 
+
+@pytest.fixture()
+def sample_data_lon_lat():
+    ny, nx = 100, 100
+    dlon, dlat = 0.01, 0.01
+    lon = np.arange(nx)*dlon + 100
+    lat = np.arange(ny)*dlat - 45
+    return lon, lat
+
 @pytest.fixture()
 def square_verts():
-    return np.array([[0,0], [1,0], [1,1], [0,1], [0,0]])
+    return np.array([[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5],
+                     [-0.5, 0.5], [-0.5, -0.5]])
+
+
+def circular_verts(r=1., x0=0., y0=0.):
+    n = 100
+    theta = np.linspace(0, 2*np.pi, n)
+    x = x0 + r * np.cos(theta)
+    y = y0 + r * np.sin(theta)
+    return np.vstack([y, x]).T
 
 
 def test_polygon_area(square_verts):
@@ -27,6 +45,30 @@ def test_polygon_area(square_verts):
     # try without the last vertex
     assert rclv.polygon_area(square_verts[:-1]) == 1.0
 
+    cverts = circular_verts()
+    np.testing.assert_allclose(rclv.polygon_area(cverts), np.pi, rtol=0.01)
+
+
+def test_projection():
+    verts = circular_verts()
+    lat0, lon0 = (0, 0)
+    dlon, dlat = (0.1, 0.1)
+    verts_proj_equator = rclv.project_vertices(verts, lon0, lat0, 0.1, 0.1)
+
+    # area of a circle of radius 0.1 degree at the equator
+    area_equator_expected = 388.4e6
+    np.testing.assert_allclose(rclv.polygon_area(verts_proj_equator),
+                               area_equator_expected, rtol=0.01)
+
+    lat0 = 60
+    verts_proj_60N = rclv.project_vertices(verts, lon0, lat0, 0.1, 0.1)
+    np.testing.assert_allclose(rclv.polygon_area(verts_proj_60N),
+                               area_equator_expected/2, rtol=0.01)
+
+    lat0 = -60
+    verts_proj_60S = rclv.project_vertices(verts, lon0, lat0, 0.1, 0.1)
+    np.testing.assert_allclose(rclv.polygon_area(verts_proj_60S),
+                               area_equator_expected/2, rtol=0.01)
 
 def test_get_local_region():
     # create some data
@@ -54,8 +96,8 @@ def test_is_contour_closed(square_verts):
 
 
 def test_point_in_contour(square_verts):
-    assert rclv.point_in_contour(square_verts, (0.5, 0.5))
-    assert not rclv.point_in_contour(square_verts, (1.5, 0.5))
+    assert rclv.point_in_contour(square_verts, (0., 0.))
+    assert not rclv.point_in_contour(square_verts, (1., 0.))
 
 
 def test_contour_area(square_verts):
@@ -63,6 +105,19 @@ def test_contour_area(square_verts):
     assert region_area == 1.0
     assert hull_area == 1.0
     assert convex_def == 0.0
+
+
+def test_contour_area_projected(square_verts):
+    lon0, lat0 = 0, 0
+    dlon, dlat = 1, 1
+    verts_proj = rclv.project_vertices(square_verts, lon0, lat0, dlon, dlat)
+    region_area, hull_area, convex_def = rclv.contour_area(verts_proj)
+
+    square_area_equator = 123.64311711e8
+
+    np.testing.assert_allclose(region_area, square_area_equator)
+    np.testing.assert_allclose(hull_area, square_area_equator)
+    np.testing.assert_allclose(convex_def, 0.0)
 
 
 def test_contour_around_maximum(sample_data_and_maximum):
@@ -102,6 +157,26 @@ def test_convex_contour_around_maximum(sample_data_and_maximum):
 
     # for this specific psi, contour should be symmetric around maximum
     assert tuple(con[:-1].mean(axis=0).astype('int')) == ji
+
+
+
+def test_convex_contour_around_maximum_projected(sample_data_and_maximum,
+                                                 sample_data_lon_lat):
+    psi, ji, psi_max = sample_data_and_maximum
+    lon, lat = sample_data_lon_lat
+
+    proj_kwargs = dict(
+        dlon=lon[1] - lon[0],
+        dlat=lat[1] - lat[0],
+        lon0=lon.mean(),
+        lat0=lat.mean(),
+    )
+
+    # step determines how precise the contour identification is
+    step = 0.001
+    con, area = rclv.convex_contour_around_maximum(psi, ji, step,
+                                proj_kwargs=proj_kwargs)
+
 
 
 def test_find_convex_contours(sample_data_and_maximum):


### PR DESCRIPTION
This PR adds the ability to specify lon and lat when identifying convex contours. The lon and lat are used to create local tangent plane projections when calculating contour area and convexity deficiency.

Partially fixes #17 