### PR TITLE
step_time_issue

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ Transcoding is done via the `floater_convert` script, which is installed with th
 $ floater_convert
 usage: floater_convert [-h] [--float_file_prefix PREFIX] [--float_buf_dim N]
                        [--progress] [--input_dir DIR] [--output_format FMT]
-                       [--keep_fields FIELDS] [--ref_time RT] [--step_time ST]
+                       [--keep_fields FIELDS] [--ref_time RT]
                        [--output_dir OD] [--output_prefix OP]
                        output_file
 ```

--- a/floater/test/test_utils.py
+++ b/floater/test/test_utils.py
@@ -102,7 +102,7 @@ def test_floats_to_netcdf(tmpdir, mitgcm_float_datadir_csv):
     # most options
     utils.floats_to_netcdf(input_dir=input_dir, output_fname='test',
                            float_file_prefix='float_trajectories',
-                           ref_time='1993-01-01', step_time='86400',
+                           ref_time='1993-01-01',
                            output_dir=output_dir, output_prefix='prefix_test')
 
     # filename prefix test
@@ -125,7 +125,7 @@ def test_floats_to_netcdf(tmpdir, mitgcm_float_datadir_csv):
         np.testing.assert_almost_equal(mfdm[var].values[0][0], value, 8)
 
     # times test
-    times = [(0, np.datetime64('1993-01-01', 'ns')), (1, np.datetime64('1993-01-02', 'ns'))]
-    for i, time in times:
-        assert mfdl['time'][i].values == i
+    times = [(0, 0, np.datetime64('1993-01-01', 'ns')), (1, 86400, np.datetime64('1993-01-02', 'ns'))]
+    for i, sec, time in times:
+        assert mfdl['time'][i].values == sec
         assert mfdm['time'][i].values == time

--- a/scripts/floater_convert
+++ b/scripts/floater_convert
@@ -16,7 +16,7 @@ parser.add_argument('--progress', dest='progress', action='store_true')
 parser.set_defaults(progress=False)
 
 parser.add_argument('--input_dir', default='./', metavar='DIR',
-                   help='directory in which to find the MITgcm float data')
+                    help='directory in which to find the MITgcm float data')
 
 parser.add_argument('--output_format', choices=['pytables','bcolz','pandas','netcdf'],
                     default='pytables', metavar='FMT',
@@ -36,11 +36,8 @@ parser.add_argument('--output_prefix', default='float_trajectories', metavar='OP
 parser.add_argument('--ref_time', default=None, metavar='RT',
                     help='reference time, format: YYYY-MM-DD')
 
-parser.add_argument('--step_time', default=86400, metavar='ST',
-                    help='step time, unit: second')
-
 parser.add_argument('output_file',
-                   help='the output filename')
+                    help='the output filename')
 
 args = parser.parse_args()
 
@@ -71,6 +68,5 @@ elif args.output_format=='netcdf':
     utils.floats_to_netcdf(args.input_dir, args.output_file,
                         float_file_prefix=args.float_file_prefix,
                         ref_time=args.ref_time,
-                        step_time=args.step_time,
                         output_dir=args.output_dir,
                         output_prefix=args.output_prefix)


### PR DESCRIPTION
This pull request fixes the `step_time` issue mentioned in #53. In this latest version, the option `--step_time` is removed from `floater_convert`. Also, when `--ref_time` is `None`, we will get `time` values from MITgcm output directly, rather than redefining iteration numbers.

cc: @rabernat, @anirban89, @nathanieltarshish