### PR TITLE
dimension_issue

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ Transcoding is done via the `floater_convert` script, which is installed with th
 $ floater_convert
 usage: floater_convert [-h] [--float_file_prefix PREFIX] [--float_buf_dim N]
                        [--progress] [--input_dir DIR] [--output_format FMT]
-                       [--keep_fields FIELDS] [--ref_time RT]
+                       [--keep_fields FIELDS] [--ref_time RT] [--pkl_path PP]
                        [--output_dir OD] [--output_prefix OP]
                        output_file
 ```

--- a/floater/generators.py
+++ b/floater/generators.py
@@ -353,7 +353,7 @@ class FloatSet(object):
         if type(ds1d) == xr.core.dataarray.DataArray:
             ds1d = ds1d.to_dataset()
         df = ds1d.to_dataframe()
-        var_list = list(df)
+        var_list = list(df.columns)
         index_dict = {'index': range(1, Nt+1)}
         var_dict = {var: np.zeros(Nt) for var in var_list}
         frame_dict = {}

--- a/floater/generators.py
+++ b/floater/generators.py
@@ -334,7 +334,7 @@ class FloatSet(object):
 
 
     def npart_to_2D_array(self, ds1d):
-        """Constructs 2D Dataset from 1D DataArray/DataSet of single or multi-variable.
+        """Constructs 2D Dataset from 1D DataArray/Dataset of single or multi-variable.
 
         PARAMETERS
         ----------
@@ -361,6 +361,7 @@ class FloatSet(object):
         frame_dict.update(var_dict)
         frame = pd.DataFrame(frame_dict)
         framei = frame.set_index('index')
+        framei.columns = var_list
         if self.model_grid is not None:
             ocean_bools = self.ocean_bools
         else:
@@ -368,11 +369,19 @@ class FloatSet(object):
         framei.loc[ocean_bools==True] = df.values.astype(np.float32)
         framei.loc[ocean_bools==False] = np.float32('nan')
         data_vars = {}
+        dim_list = list(ds1d.dims)
+        dim_list.remove('npart')
+        dim_len = len(dim_list)
+        new_shape = (1,)*dim_len + (Ny, Nx)
+        new_dims = dim_list + ['lat', 'lon']
         for var in var_list:
-            frameir = framei[var].values.reshape(Ny, Nx)
-            data_vars.update({var: (['lat', 'lon'], frameir)})
+            frameir = framei[var].values
+            frameir.shape = new_shape
+            data_vars.update({var: (new_dims, frameir)})
+        coords = {}
         lon = np.float32(self.x)
         lat = np.float32(self.y)
-        coords = {'lat': (['lat'], lat), 'lon': (['lon'], lon)}
+        coords.update({dim: ([dim], ds1d[dim].values) for dim in dim_list})
+        coords.update({'lat': (['lat'], lat), 'lon': (['lon'], lon)})
         ds2d = xr.Dataset(data_vars=data_vars, coords=coords)
         return ds2d

--- a/floater/utils.py
+++ b/floater/utils.py
@@ -222,7 +222,8 @@ def floats_to_castra(input_dir, output_fname, progress=False, **kwargs):
 def floats_to_netcdf(input_dir, output_fname,
                      float_file_prefix='float_trajectories',
                      ref_time=None, output_dir='./',
-                     output_prefix='float_trajectories'):
+                     output_prefix='float_trajectories',
+                     pkl_path=None):
     """Convert MITgcm float data to NetCDF format.
 
     Parameters
@@ -242,6 +243,7 @@ def floats_to_netcdf(input_dir, output_fname,
     """
     import dask.dataframe as dd
     import xarray as xr
+    from floater.generators import FloatSet
     from glob import glob
     from tqdm import tqdm
 
@@ -270,6 +272,9 @@ def floats_to_netcdf(input_dir, output_fname,
         var_shape = (1, len(npart))
         data_vars = {var_name: (['time', 'npart'], dfcs[var_name].values.astype(np.float32).reshape(var_shape)) for var_name in var_names}
         ds = xr.Dataset(data_vars, coords={'time': time, 'npart': npart})
+        if pkl_path is not None:
+            fs = FloatSet(load_path=pkl_path)
+            ds = fs.npart_to_2D_array(ds)
         output_path = os.path.join(output_dir, output_fname)
         if not os.path.exists(output_path):
             os.makedirs(output_path)

--- a/floater/utils.py
+++ b/floater/utils.py
@@ -251,7 +251,7 @@ def floats_to_netcdf(input_dir, output_fname,
 
     match_pattern = float_file_prefix + '.*.csv'
     float_files = glob(os.path.join(input_dir, match_pattern))
-    float_timesteps = set(sorted([int(float_file[-22:-12]) for float_file in float_files]))
+    float_timesteps = sorted(list({int(float_file[-22:-12]) for float_file in float_files}))
 
     float_columns = ['npart', 'time', 'x', 'y', 'z', 'u', 'v', 'vort']
     var_names = float_columns[2:]

--- a/scripts/floater_convert
+++ b/scripts/floater_convert
@@ -36,6 +36,9 @@ parser.add_argument('--output_prefix', default='float_trajectories', metavar='OP
 parser.add_argument('--ref_time', default=None, metavar='RT',
                     help='reference time, format: YYYY-MM-DD')
 
+parser.add_argument('--pkl_path', default=None, metavar='PP',
+                    help='path to the pickle file')
+
 parser.add_argument('output_file',
                     help='the output filename')
 
@@ -69,4 +72,5 @@ elif args.output_format=='netcdf':
                         float_file_prefix=args.float_file_prefix,
                         ref_time=args.ref_time,
                         output_dir=args.output_dir,
-                        output_prefix=args.output_prefix)
+                        output_prefix=args.output_prefix,
+                        pkl_path=args.pkl_path)

--- a/scripts/floater_convert
+++ b/scripts/floater_convert
@@ -37,7 +37,7 @@ parser.add_argument('--ref_time', default=None, metavar='RT',
                     help='reference time, format: YYYY-MM-DD')
 
 parser.add_argument('--pkl_path', default=None, metavar='PP',
-                    help='path to the pickle file')
+                    help='path to the pickle file of the FloatSet used to generate initial positions')
 
 parser.add_argument('output_file',
                     help='the output filename')


### PR DESCRIPTION
This pull request fixes the dimension issue of `npart_to_2D_array`. Instead of losing track of dimensions other than `npart` previously, the updated version is able to keep all dimension information documented in `ds1d`. This latest method is also included in `floats_to_netcdf` if the variable `pkl_path` is given.

cc: @rabernat