### PR TITLE
accelerate_workflow

### DIFF
--- a/floater/generators.py
+++ b/floater/generators.py
@@ -365,8 +365,12 @@ class FloatSet(object):
             ocean_bools = self.ocean_bools
         else:
             ocean_bools = np.zeros(Nt, dtype=bool)==False
-        da = np.squeeze(ds1d.to_array().values).transpose()
-        framei.loc[ocean_bools==True] = da.astype(np.float32)
+        da = ds1d.to_array().values
+        axis_len = len(da.shape) - 2
+        axis = tuple(np.linspace(1, axis_len, axis_len, dtype=np.int32))
+        das = np.squeeze(da, axis=axis)
+        dast = das.transpose()
+        framei.loc[ocean_bools==True] = dast.astype(np.float32)
         framei.loc[ocean_bools==False] = np.float32('nan')
         dim_list = list(ds1d.dims)
         dim_list.remove('npart')

--- a/floater/generators.py
+++ b/floater/generators.py
@@ -352,9 +352,9 @@ class FloatSet(object):
         Nt = Nx*Ny
         if type(ds1d) == xr.core.dataarray.DataArray:
             ds1d = ds1d.to_dataset()
-        index_dict = {'index': np.linspace(1, Nt, Nt, dtype=np.int32)}
+        index_dict = {'index': np.arange(1, Nt+1, dtype=np.int32)}
         var_list = list(ds1d.data_vars)
-        var_dict = {var: np.zeros(Nt, dtype=np.float32) for var in var_list}
+        var_dict = {var: np.full(Nt, np.nan, dtype=np.float32) for var in var_list}
         frame_dict = {}
         frame_dict.update(index_dict)
         frame_dict.update(var_dict)
@@ -364,14 +364,13 @@ class FloatSet(object):
         if self.model_grid is not None:
             ocean_bools = self.ocean_bools
         else:
-            ocean_bools = np.zeros(Nt, dtype=bool)==False
+            ocean_bools = np.full(Nt, True, dtype=bool)
         da = ds1d.to_array().values
         axis_len = len(da.shape) - 2
-        axis = tuple(np.linspace(1, axis_len, axis_len, dtype=np.int32))
+        axis = tuple(np.arange(1, axis_len+1, dtype=np.int32))
         das = np.squeeze(da, axis=axis)
         dast = das.transpose()
         framei.loc[ocean_bools==True] = dast.astype(np.float32)
-        framei.loc[ocean_bools==False] = np.float32('nan')
         dim_list = list(ds1d.dims)
         dim_list.remove('npart')
         dim_len = len(dim_list)

--- a/floater/generators.py
+++ b/floater/generators.py
@@ -344,7 +344,7 @@ class FloatSet(object):
         RETURNS
         -------
         ds2d : 2D Dataset
-            Two-dimensional dataset of physical variable(s) with dimensions 'lat' and 'lon'
+            Two-dimensional dataset of physical variable(s) with dimensions 'y0' and 'x0'
         """
 
         Nx = self.Nx

--- a/floater/test/test_generators.py
+++ b/floater/test/test_generators.py
@@ -237,13 +237,13 @@ def test_npart_to_2D_array():
         assert da2d.to_array().values.shape == (1, 1, 1, fs.Ny, fs.Nx)
         assert ds2d.to_array().values.shape == (3, 1, 1, fs.Ny, fs.Nx)
         # dimension test
-        assert da2d.dims == {'date': 1, 'loc': 1, 'lat': 9, 'lon': 9}
-        assert ds2d.dims == {'date': 1, 'loc': 1, 'lat': 9, 'lon': 9}
+        assert da2d.dims == {'date': 1, 'loc': 1, 'y0': 9, 'x0': 9}
+        assert ds2d.dims == {'date': 1, 'loc': 1, 'y0': 9, 'x0': 9}
         # coordinates test
-        np.testing.assert_allclose(da2d.lon.values, fs.x)
-        np.testing.assert_allclose(da2d.lat.values, fs.y)
-        np.testing.assert_allclose(ds2d.lon.values, fs.x)
-        np.testing.assert_allclose(ds2d.lat.values, fs.y)
+        np.testing.assert_allclose(da2d.x0.values, fs.x)
+        np.testing.assert_allclose(da2d.y0.values, fs.y)
+        np.testing.assert_allclose(ds2d.x0.values, fs.x)
+        np.testing.assert_allclose(ds2d.y0.values, fs.y)
         # values test
         da1d_values = values_list[0][0][0]
         da2d_values_full = da2d.to_array().values[0].ravel()

--- a/floater/test/test_utils.py
+++ b/floater/test/test_utils.py
@@ -115,7 +115,7 @@ def test_floats_to_netcdf(tmpdir, mitgcm_float_datadir_csv):
     mfdm = xr.open_mfdataset('test_netcdf/prefix_test.*.nc')
 
     # dimensions test
-    dims = [{'time': 2, 'npart': 40}, {'time': 2, 'lat': 4, 'lon': 10}]
+    dims = [{'time': 2, 'npart': 40}, {'time': 2, 'y0': 4, 'x0': 10}]
     assert mfdl.dims == dims[0]
     assert mfdm.dims == dims[1]
 


### PR DESCRIPTION
This pull request modifies some expensive steps in `npart_to_2D_array` regarding dtype and pandas DataFrame, reducing the time cost of `floater_convert` from 2 minutes to 30 seconds per timestep. It also changes the names of the output coordinates from `lat` and `lon` to `y0` and `x0`, respectively.

cc: @rabernat